### PR TITLE
Fixed room disallow

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -25,7 +25,7 @@ Disallow: /more-from-seller/
 Disallow: /mobile/
 Disallow: /resp/
 Disallow: /similar/
-Disallow: /room/
+Disallow: */room/
 Disallow: /*gp=*
 Disallow: /*uw=*
 Disallow: /*al=*


### PR DESCRIPTION
This was my mistake - the way it was written, only 1stdibs.com/room/* would be disallowed. By adding a wildcard character before /room/, all URLs on 1stdibs.com containing /room/ will now be disallowed, which was the intended effect.

### IMPORTANT

Commits to robots.txt landing in master will be pushed to production automatically. Only merge pull requests that you're confidant should be pushed to production.
