### PR TITLE
clean-up: remove st param

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -72,7 +72,6 @@ Disallow: /*carat-weight=*
 Disallow: /*stone-cut=*
 Disallow: /*latest=*
 Disallow: /*forceLocale=*
-Disallow: /*st=*
 Disallow: /*matching-sets=*
 Noindex: */room/*
 


### PR DESCRIPTION
This param was used for search forced facets, but we moved that logic to query builder and its no longer needed (there is nothing that can add this param), so while I remember what it was used for, I would like to clean this up.