### PR TITLE
GROWTH-5551 Allow: /soa/graphql/

### DIFF
--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Allow: /soa/graphql/
 Disallow: /search/
 Disallow: /soa/
 Disallow: /administration/
@@ -61,4 +62,3 @@ Disallow:
 
 User-agent: Pinterest
 Crawl-delay: 5
-


### PR DESCRIPTION
### Description
As noted in the previously delivered Quick Hits, Googlebot’s Web Rendering Service is having difficulty seeing content on the page but is triggering the URL incessantly. This suggests that the directive is already being ignored inconsistently. We recommend removing the block from the URL and adding an x robots noindex to allow the content to always be indexed, but the GraphQL endpoint not. 

iPullRank recommends returning a noindex HTTP header from the GraphQL endpoint. This should allow Google’s Web Rendering Service to access the endpoint for the purposes of rendering content, but not index the URL itself.

Summary:

- Add `Allow: /soa/graphql/` to robots.txt

- Return a `noindex` HTTP header from the GraphQL endpoint: `X-Robots-Tag: noindex`

More info: https://developers.google.com/search/reference/robots_meta_tag
### Ticket
https://1stdibs.atlassian.net/browse/GROWTH-5551
### Linked PRs
https://github.com/1stdibs/dibs-graphql/pull/9121