### PR TITLE
GROWTH-6049: disallow:/soa/graphql/ide

### DIFF
--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -2,6 +2,7 @@ User-agent: *
 Allow: /soa/graphql/
 Disallow: /search/
 Disallow: /soa/
+Disallow: /soa/graphql/graphiql/
 Disallow: /administration/
 Disallow: /cgi-bin/
 Disallow: /vpv/

--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /soa/graphql/
 Disallow: /search/
 Disallow: /soa/
-Disallow: /soa/graphql/graphiql/
+Disallow: /soa/graphql/ide/
 Disallow: /administration/
 Disallow: /cgi-bin/
 Disallow: /vpv/


### PR DESCRIPTION
Description: Google bot crawls graphql playground and counts them as soft 404s. A graphql pr will move the playground to /graphiql and this pr will disallow the bot from crawling it by adding a disallow rule for /soa/graphql/graphiql. This pr will go out before the graphql pr.

ticket: https://1stdibs.atlassian.net/browse/GROWTH-6049

graphql pr: https://github.com/1stdibs/dibs-graphql/pull/10374


