### PR TITLE
GROWTH-6226: disallow:/soa/graphql/ide without trailing slash

### DIFF
--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /soa/graphql/
 Disallow: /search/
 Disallow: /soa/
-Disallow: /soa/graphql/ide/
+Disallow: /soa/graphql/ide
 Disallow: /administration/
 Disallow: /cgi-bin/
 Disallow: /vpv/


### PR DESCRIPTION
https://github.com/1stdibs/dibs-graphql/pull/10443 is updating the graphql playground to accept /soa/graphql/ide with and without trailing slash. Therefore, we want to update the rule to exclude the trailing slash in respond to that change.