### PR TITLE
feat: GROWTH-6367 allow to crawl soa/graphql/* routes

### DIFF
--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -1,5 +1,8 @@
 User-agent: *
 Allow: /soa/graphql/
+Allow: /soa/graphql$
+Allow: /soa/graphql?*
+Allow: /soa/graphql/?*
 Disallow: /search/
 Disallow: /soa/
 Disallow: /administration/

--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -1,8 +1,5 @@
 User-agent: *
-Allow: /soa/graphql/$
-Allow: /soa/graphql$
-Allow: /soa/graphql?*
-Allow: /soa/graphql/?*
+Allow: /soa/graphql/
 Disallow: /search/
 Disallow: /soa/
 Disallow: /administration/

--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -1,8 +1,5 @@
 User-agent: *
-Allow: /soa/graphql/
-Allow: /soa/graphql$
-Allow: /soa/graphql?*
-Allow: /soa/graphql/?*
+Allow: /soa/graphql*
 Disallow: /search/
 Disallow: /soa/
 Disallow: /administration/

--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Allow: /soa/graphql*
+Allow: /soa/graphql
 Disallow: /search/
 Disallow: /soa/
 Disallow: /administration/


### PR DESCRIPTION
### Description

we want google to stop indexing `soa/graphql/*` routes such as https://www.google.com/search?q=site:1stdibs.com/soa/graphql/&rlz=1C5CHFA_enUS876US876&filter=0&biw=1341&bih=706

In order to tell google that those pages should be no longer indexable, we should let search engines crawl those since they will return the `X-Robots-Tag: noindex` HTTP response header.

For more context https://developers.google.com/search/docs/advanced/crawling/block-indexing

### Ticket

https://1stdibs.atlassian.net/browse/GROWTH-6367


![Screenshot 2021-03-19 at 10 57 49](https://user-images.githubusercontent.com/5259242/111755621-f8c98280-88a1-11eb-8145-689bc9612261.png)

### IMPORTANT

Commits to robots.txt landing in master will be pushed to production automatically. Only merge pull requests that you're confident should be pushed to production.




