### PR TITLE
FI-2295 disallow GoogleOther from crawling entire site

### DIFF
--- a/www.1stdibs.com/robots.txt
+++ b/www.1stdibs.com/robots.txt
@@ -214,11 +214,7 @@ Disallow: /es/view/
 Disallow: /es/vpv/
 
 User-agent: GoogleOther
-Disallow: /de/photos/
-Disallow: /fr/photos/
-Disallow: /it/photos/
-Disallow: /es/photos/
-Disallow: /photos/
+Disallow: /
 
 User-agent: AdsBot-Google
 Disallow:


### PR DESCRIPTION
going off of Google's documentation for how to block crawler from whole site:
* https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt#useful-robots.txt-rules
<img width="1028" alt="Screenshot 2024-05-07 at 3 44 51 PM" src="https://github.com/1stdibs/robots.txt/assets/5166809/74fb2419-7f5f-4971-8fb8-2870772bd6bb">
